### PR TITLE
Request method DELETE incorrectly mapped

### DIFF
--- a/wazirx_sapi_client/rest/client.py
+++ b/wazirx_sapi_client/rest/client.py
@@ -51,7 +51,7 @@ class Client(BaseClient):
         elif request_method == "post":
             response = requests.post(url, data=kwargs, headers=headers)
         elif request_method == "delete":
-            response = requests.post(url, data=kwargs, headers=headers)
+            response = requests.delete(url, data=kwargs, headers=headers)
         if response is not None:
             return response.status_code, response.json()
         raise BaseException("Invalid Request Type")


### PR DESCRIPTION
Request method DELETE was incorrectly using request method POST when sending a request. Cancelling order before this fix was impossible using this python rest connector.

