### PR TITLE
Fixed python version check for 3.11

### DIFF
--- a/wazirx_sapi_client/rest/__init__.py
+++ b/wazirx_sapi_client/rest/__init__.py
@@ -1,6 +1,8 @@
 import sys
 
-if int(sys.version[0]) < 3 or int(sys.version[2]) < 7:
+python_version = sys.version.split(".")
+
+if int(python_version[0]) < 3 or int(python_version[1]) < 7:
     raise BaseException("Python>=3.7 required")
 
 from wazirx_sapi_client.rest.client import Client


### PR DESCRIPTION
Old code leads to `BaseException: Python>=3.7 required` for >=v3.10. This fix splits the version string at `.` to load each version separately.
